### PR TITLE
feat(cwe): add CreateSecurityGroup

### DIFF
--- a/c7n/cwe.py
+++ b/c7n/cwe.py
@@ -49,6 +49,10 @@ class CloudWatchEvents:
             'ids': 'requestParameters.dBInstanceIdentifier',
             'source': 'rds.amazonaws.com'},
 
+        'CreateSecurityGroup': {
+            'ids': 'responseElements.groupId',
+            'source': 'ec2.amazonaws.com'},
+
         'CreateVolume': {
             'ids': 'responseElements.volumeId',
             'source': 'ec2.amazonaws.com'},


### PR DESCRIPTION
## what

- add CreateSecurityGroup as an easy event

## why

This allows us to write the following

```yaml
    mode:
      type: cloudtrail
      events:
        - CreateSecurityGroup
```

Instead of

```yaml
    mode:
      type: cloudtrail
      events:
        - source: ec2.amazonaws.com
          event: CreateSecurityGroup
          ids: "responseElements.groupId"
```